### PR TITLE
chore(deps): update @form8ion/remark-lint-preset to 7.0.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantically-released",
       "license": "MIT",
       "dependencies": {
-        "@form8ion/remark-lint-preset": "6.0.7"
+        "@form8ion/remark-lint-preset": "7.0.0-beta.1"
       },
       "devDependencies": {
         "@travi/eslint-config-travi": "1.8.8",
@@ -579,9 +579,9 @@
       }
     },
     "node_modules/@form8ion/remark-lint-preset": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@form8ion/remark-lint-preset/-/remark-lint-preset-6.0.7.tgz",
-      "integrity": "sha512-SART6hyYNoz4GFR9OtXy+XUaMp+S73bUjVAZal8+4KzXAmlF2z5UBfmeX94hzZtMJOMEsqIsYLshBoegAep1UA==",
+      "version": "7.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@form8ion/remark-lint-preset/-/remark-lint-preset-7.0.0-beta.1.tgz",
+      "integrity": "sha512-CzAsBiNyWAptlmFtOS2Bps3TrQixhiSIaj8hYS7PFllXmDaHOuSxb88ixZmxNvk2FoCrlX8PytgOM8gL47FX+Q==",
       "license": "MIT",
       "dependencies": {
         "remark-gfm": "^4.0.0",
@@ -591,6 +591,7 @@
         "remark-lint-no-empty-url": "4.0.1",
         "remark-lint-no-tabs": "4.0.1",
         "remark-lint-ordered-list-marker-value": "4.0.1",
+        "remark-lint-table-cell-padding": "5.1.1",
         "remark-lint-unordered-list-marker-style": "4.0.1",
         "remark-preset-lint-recommended": "7.0.1",
         "remark-validate-links": "13.1.0"
@@ -11328,6 +11329,27 @@
         "devlop": "^1.0.0",
         "mdast-util-phrasing": "^4.0.0",
         "micromark-util-character": "^2.0.0",
+        "unified-lint-rule": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-lint-table-cell-padding": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-table-cell-padding/-/remark-lint-table-cell-padding-5.1.1.tgz",
+      "integrity": "sha512-6fgVA1iINBoAJaZMOnSsxrF9Qj9+hmCqrsrqZqgJJETjT1ODGH64iAN1/6vHR7dIwmy73d6ysB2WrGyKhVlK3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "pluralize": "^8.0.0",
         "unified-lint-rule": "^3.0.0",
         "unist-util-position": "^5.0.0",
         "unist-util-visit-parents": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     }
   },
   "dependencies": {
-    "@form8ion/remark-lint-preset": "6.0.7"
+    "@form8ion/remark-lint-preset": "7.0.0-beta.1"
   },
   "devDependencies": {
     "@travi/eslint-config-travi": "1.8.8",


### PR DESCRIPTION
## Summary

Pulls in [form8ion/remark-lint-preset#645](https://github.com/form8ion/remark-lint-preset/pull/645)
(table-cell-padding enforcement, `unordered-list-marker-style` switched
from `*` to `-`) via its `beta` npm dist-tag, ahead of that change
promoting to the `latest` channel there.

Targets this repo's `beta` branch, matching the upstream release channel.

## Breaking change

Same breaking change as the upstream PR, passed through: any existing `*`
bullet, or table mixing padded and unpadded rows, now fails lint under
`--frail`, where it previously passed. Consumers need to reformat (Prettier's
default markdown output already satisfies both) before upgrading.

## Validation

`npm test` (lint:md, lint:js, lint:sensitive, lint:peer, lint:engines,
lint:publish) passes clean — this repo's own README has no bullets or
tables to conflict with either rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)